### PR TITLE
Limit HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ As of version 0.6.0, the following [**delegated**](https://learn.microsoft.com/e
 
 Refer to the [releases page](https://github.com/spsprinkles/timeline-calendar/releases) for specific details.
 
-| Version | Date             | Comments        |
-| ------- | ---------------- | --------------- |
-| 0.6.0   | January 21, 2024 | New features (including Outlook calendar support) & bug fixes |
+| Version | Date              | Comments        |
+| ------- | ----------------- | --------------- |
+| 0.6.1   | March 15, 2024    | Several bug fixes |
+| 0.6.0   | January 21, 2024  | New features (including Outlook calendar support) & bug fixes |
 | 0.5.3   | November 27, 2023 | Several bug fixes |
-| 0.5.2   | October 20, 2023 | Initial release |
+| 0.5.2   | October 20, 2023  | Initial release |
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Refer to the [releases page](https://github.com/spsprinkles/timeline-calendar/re
 
 | Version | Date              | Comments        |
 | ------- | ----------------- | --------------- |
-| 0.6.1   | March 15, 2024    | Several bug fixes |
+| 0.6.1   | March 15, 2024    | Several enhancements & bug fixes |
 | 0.6.0   | January 21, 2024  | New features (including Outlook calendar support) & bug fixes |
 | 0.5.3   | November 27, 2023 | Several bug fixes |
 | 0.5.2   | October 20, 2023  | Initial release |

--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Timeline Calendar",
     "id": "fdcba3a4-d4a6-4ac7-a370-98c7d5d8e7db",
-    "version": "0.6.0.1",
+    "version": "0.6.1.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Timeline Calendar",
-  "version": "0.6.0.1",
+  "version": "0.6.1",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0"

--- a/src/webparts/timelineCalendar/components/DirectoryPicker.tsx
+++ b/src/webparts/timelineCalendar/components/DirectoryPicker.tsx
@@ -118,7 +118,7 @@ export default class AsyncDropdown extends React.Component<IDirectoryPickerProps
                 .filter("userType eq 'Member'") //cannot filter on userType with just User.ReadBasic.All perms
                 .search(`"displayName:${encodedQuery}" OR "mail:${encodedQuery}"`)
                 .header('ConsistencyLevel', 'eventual')
-                //.orderby ???
+                .orderby("displayName") //ascending is default
                 //.count(true)
                 .get((error:GraphError, response:any, rawResponse?:any) => {
                   if (error)
@@ -157,6 +157,7 @@ export default class AsyncDropdown extends React.Component<IDirectoryPickerProps
                 //Switch to search instead to match portion of group name
                 .search(`"displayName:${encodedQuery}" OR "mail:${encodedQuery}"`)
                 .header('ConsistencyLevel', 'eventual')
+                .orderby("displayName") //ascending is default
                 .get((error:GraphError, response:any, rawResponse?:any) => {
                   if (error)
                     resolve(error.message);

--- a/src/webparts/timelineCalendar/components/MonacoPanelEditor.tsx
+++ b/src/webparts/timelineCalendar/components/MonacoPanelEditor.tsx
@@ -108,8 +108,16 @@ export default class MonacoPanelEditor extends React.Component<IMonacoPanelEdito
         this.setState({isOpen: false});
 
         //Should the value be saved?
-        if (doSave)
+        if (doSave) {
+          if (this.props.language == 'css' || this.props.language == 'html') {
+            //Extra protection for IE
+            this.tempValue = this.tempValue.replace(/javascript:/g, '');
+            this.tempValue = this.tempValue.replace(/&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;/g, '');
+            this.tempValue = this.tempValue.replace(/&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058/g, '');
+            this.tempValue = this.tempValue.replace(/&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A/g, '');
+          }
           this.props.onValueChanged(this.tempValue);
+        }
     }
 
     //<PrimaryButton onClick={(e) => this.closePanel(e, true)} styles={this.buttonStyles}>Save</PrimaryButton>


### PR DESCRIPTION
Limits which HTML elements can be used in row/group HTML and other areas (by using XSS library). Also enhances several existing capabilities & adds bug fixes including:
- Checking for blank & invalid **start** dates
- Hiding lists named with _@thread.skype_wiki_ in SP list selector
- Sorting user and group results from Graph API
- Automatically removing prefixed $filter= text from Outlook calendar **Filter Query** input
- Fixed issue with advanced _fieldValueMapping_ property for Outlook calendars not reflecting mapped value in tooltip
- Added support for Calculated columns formatted as dates in the SharePoint list **Start** & **End** date selectors