### PR TITLE
All day bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Refer to the [releases page](https://github.com/spsprinkles/timeline-calendar/re
 
 | Version | Date              | Comments        |
 | ------- | ----------------- | --------------- |
-| 0.6.1   | March 15, 2024    | Several enhancements & bug fixes |
+| 0.6.1   | March 18, 2024    | Several enhancements & bug fixes |
 | 0.6.0   | January 21, 2024  | New features (including Outlook calendar support) & bug fixes |
 | 0.5.3   | November 27, 2023 | Several bug fixes |
 | 0.5.2   | October 20, 2023  | Initial release |

--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Timeline Calendar",
     "id": "fdcba3a4-d4a6-4ac7-a370-98c7d5d8e7db",
-    "version": "0.6.1.0",
+    "version": "0.6.1.1",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Timeline Calendar",
-  "version": "0.6.1",
+  "version": "0.6.1.1",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0"

--- a/src/webparts/timelineCalendar/TimelineCalendarWebPart.ts
+++ b/src/webparts/timelineCalendar/TimelineCalendarWebPart.ts
@@ -2059,7 +2059,7 @@ ${this.instanceId}
                       placeholder: " ", //need a space because blank just shows the title
                       type: CustomCollectionFieldType.string,
                       required: false,
-                      deferredValidationTime: 1000,
+                      //deferredValidationTime: 1000, //was using this but then quickly-typed-and-then-saved changes were not actually saved
                       //Oddly named: This is really the "perform field validation" function
                       onGetErrorMessage: (value: string, index: number, item: ICalendarItem) => {
                         //NOTE: "this" is just the field object


### PR DESCRIPTION
Forcing default values for list & calendar configs which fixes issue with list "extendEndTimeAllDay" prop. Also, setting Outlook calendar all day events so their end date shows as the end of the day versus 00:00 the next day.