### PR TITLE
Fixed 0.6.2 with full version #

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Timeline Calendar",
     "id": "fdcba3a4-d4a6-4ac7-a370-98c7d5d8e7db",
-    "version": "0.6.2",
+    "version": "0.6.2.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,


### PR DESCRIPTION
Needed to add training .0 for valid package manifest validation