### PR TITLE
Fixed Outlook calendar skipNumber bug

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Timeline Calendar",
     "id": "fdcba3a4-d4a6-4ac7-a370-98c7d5d8e7db",
-    "version": "0.6.3.0",
+    "version": "0.6.3.1",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelinecalendar",
-  "version": "0.6.3",
+  "version": "0.6.3.1",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0"

--- a/src/webparts/timelineCalendar/components/TimelineCalendar.tsx
+++ b/src/webparts/timelineCalendar/components/TimelineCalendar.tsx
@@ -2739,8 +2739,8 @@ export default class TimelineCalendar extends React.Component<ITimelineCalendarP
             const nextLink = response["@odata.nextLink"] as string;
             if (nextLink) {
               //Query for more events (get the next page)
-              const eqIndex = nextLink.lastIndexOf("=");
-              const skipNumber = Number(nextLink.substring(eqIndex + 1));
+              const url = new URL(nextLink);
+              skipNumber = Number(url.searchParams.get("$skip"));
               return this.queryCalendar(calObj, calConfigs, existingEvent, skipNumber, startDate, endDate);
             }
             //Check if another date range should be queried
@@ -2752,8 +2752,8 @@ export default class TimelineCalendar extends React.Component<ITimelineCalendarP
               endDate = tempDate.toISOString();
               if (tempDate > this.getMaxDate())
                 endDate = this.getMaxDate().toISOString();
-
-              return this.queryCalendar(calObj, calConfigs, existingEvent, skipNumber, startDate, endDate);
+              //skipNumber resets to 0 for this next date batch
+              return this.queryCalendar(calObj, calConfigs, existingEvent, 0, startDate, endDate);
             }
           }
         } //no error returned


### PR DESCRIPTION
skipNumber would show as NaN for situations in which more data was needed to be queried. And resolved issue with resetting skipNumber when an additional query is needed for further dates.