### PR TITLE
Filter text for xss fix

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Timeline Calendar",
     "id": "fdcba3a4-d4a6-4ac7-a370-98c7d5d8e7db",
-    "version": "0.6.3.1",
+    "version": "0.6.3.2",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelinecalendar",
-  "version": "0.6.3.1",
+  "version": "0.6.3.2",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0"

--- a/src/webparts/timelineCalendar/components/TimelineCalendar.tsx
+++ b/src/webparts/timelineCalendar/components/TimelineCalendar.tsx
@@ -362,7 +362,6 @@ export default class TimelineCalendar extends React.Component<ITimelineCalendarP
     //Documentation: https://jsxss.com/en/options.html
     input = filterXSS(input, {
       whiteList: whiteList,
-      stripIgnoreTag: true, //prevent the "[removed]" text processing
       stripIgnoreTagBody: true, //this would completely remove <iframe> vs. escaping it
       //attributes *not* in the whitelist for a tag
       onIgnoreTagAttr: function(tag:string, name:string, value:string, isWhiteAttr:boolean) {

--- a/src/webparts/timelineCalendar/components/TimelineCalendar.tsx
+++ b/src/webparts/timelineCalendar/components/TimelineCalendar.tsx
@@ -307,11 +307,15 @@ export default class TimelineCalendar extends React.Component<ITimelineCalendarP
   }
 
   private filterTextForXSS(input:string): string {
-    //Filter to get <html><head><body><div>*Actual content*
-    if (input.indexOf("html") !== -1) {
+    if (input == null)
+      return "";
+
+    //Filter to get Actual content from <html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><body><div>Actual content
+    if (input.indexOf("<html>") !== -1) {
       const elem = document.createElement("div");
-      elem.innerHTML = input;
-      input = elem.querySelector("div").outerHTML;
+      elem.innerHTML = input; //removes html, head, and body tags but leaves <meta> tags
+      //Filter out <meta> tags and trim to remove \n\n characters
+      input = elem.innerHTML.replace(/<\/?meta*[^<>]*>/ig, '').trim();
     }
     
     //Escape additional elements besides just <script>
@@ -358,6 +362,7 @@ export default class TimelineCalendar extends React.Component<ITimelineCalendarP
     //Documentation: https://jsxss.com/en/options.html
     input = filterXSS(input, {
       whiteList: whiteList,
+      stripIgnoreTag: true, //prevent the "[removed]" text processing
       stripIgnoreTagBody: true, //this would completely remove <iframe> vs. escaping it
       //attributes *not* in the whitelist for a tag
       onIgnoreTagAttr: function(tag:string, name:string, value:string, isWhiteAttr:boolean) {


### PR DESCRIPTION
Addresses regression where html detection (intended for Outlook description fields) was invalid and was applying to SharePoint fields as well, causing null reference