### PR TITLE
Graph & advanced editor updates + visual improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-![SPFx 1.17](https://img.shields.io/badge/SPFx-1.17.2-green.svg)
+![SPFx 1.17.2](https://img.shields.io/badge/SPFx-1.17.2-green.svg)
 ![Node.js v16](https://img.shields.io/badge/Node.js-v16-green.svg)
 ![SPO](https://img.shields.io/badge/SharePoint%20Online-Compatible-green.svg)
 
@@ -27,6 +27,7 @@ Refer to the [releases page](https://github.com/spsprinkles/timeline-calendar/re
 
 | Version | Date              | Comments        |
 | ------- | ----------------- | --------------- |
+| 0.6.4   | January 17, 2025  | Graph & advanced editor updates + visual improvements |
 | 0.6.3   | August 28, 2024   | Bug fixes for event querying |
 | 0.6.2   | May 3, 2024       | Enabled advanced code editor for DoD365-Sec |
 | 0.6.1   | March 18, 2024    | Several enhancements & bug fixes |

--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Timeline Calendar",
     "id": "fdcba3a4-d4a6-4ac7-a370-98c7d5d8e7db",
-    "version": "0.6.3.2",
+    "version": "0.6.4.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelinecalendar",
-  "version": "0.6.3.2",
+  "version": "0.6.4",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0"

--- a/src/webparts/timelineCalendar/components/MonacoEditor/useMonaco.ts
+++ b/src/webparts/timelineCalendar/components/MonacoEditor/useMonaco.ts
@@ -17,42 +17,122 @@ export const useMonaco = (): {
   const [status, setStatus] = useState<EStatus>(EStatus.LOADING);
   const [error, setError] = useState<Error>(undefined);
 
-  let CDN_PATH_TO_MONACO_EDITOR = "https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/min/vs"; //orig was 0.32.1
-  // CDN_PATH_TO_MONACO_EDITOR = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.47.0/min/vs";
-
-  //aadInstanceUrl = 'https://login.microsoftonline.com' / 'https://login.microsoftonline.us' / 'https://login.microsoftonline.microsoft.scloud'
-  //cloudType = 'prod' / 'dod' / 'ag09'
-  //msGraphEndpointUrl = 'https://graph.microsoft.com' / 'https://dod-graph.microsoft.us' / 'https://dod-graph.microsoft.scloud'
-  //webDomain = 'sharepoint.com' / 'sharepoint-mil.us' (even *.dps.mil sites) / 'spo.microsoft.scloud'
-  //substrateEndpointUrl = 'https://substrate.office.com' / 'https://substrate-dod.office365.us' / 'https://substrate.exo.microsoft.scloud'
-
-  const context = AcquireContext.getContext();
-  /*context.pageContext.aadInfo {}
-    .instanceUrl: "https://login.microsoftonline.com"
-    .tenantId: {
-        _guid: 'c5807244-0000-0000-adb9-357387d2a1de'
-      }
-      userId: {
-        _guid: '7de78987-0000-0000-8d17-d19edeab9e41'
-      }
-  */
-  if (context.pageContext.legacyPageContext.aadInstanceUrl && 
-        context.pageContext.legacyPageContext.aadInstanceUrl.endsWith("microsoft.scloud"))
-    //Override the path
-    CDN_PATH_TO_MONACO_EDITOR = "https://dod365sec.spo.microsoft.scloud/sites/USAF-TipsToolsApps/code/monaco/min/vs";
+  let CDN_PATH_TO_MONACO_EDITOR = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.47.0/min/vs"; //orig was 0.32.1 "https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/min/vs"
 
   //Try to load the monaco editor
   useEffect(() => {
     (async () => {
-      try {
-        loader.config({ paths: { vs: CDN_PATH_TO_MONACO_EDITOR } });
-        const monacoObj = await loader.init();
-        setStatus(EStatus.LOADED);
-        setMonaco(monacoObj);
-      } catch (error) {
-        setStatus(EStatus.ERROR);
-        setMonaco(undefined);
-        setError(error);
+      const loadMonaco = async () => {
+        try {
+          loader.config({ paths: { vs: CDN_PATH_TO_MONACO_EDITOR } });
+          const monacoObj = await loader.init();
+          setStatus(EStatus.LOADED);
+          setMonaco(monacoObj);
+        } catch (error) {
+          setStatus(EStatus.ERROR);
+          setMonaco(undefined);
+          setError(error);
+        }
+      }
+      
+      const testUrlNetworkAccess = (url:string, defaultCheck:boolean):Promise<string> => {
+        const promise = new Promise<string>((resolve, reject) => {
+          fetch(url, {
+            //method: 'HEAD',
+            mode: 'cors'
+            //redirect: 'follow'
+          })
+          .then(response => {
+              return response.text();
+          }).then(data => {
+              if (data == null)
+                reject('');
+              else
+                if (defaultCheck) {
+                  if (data.indexOf('Version: 0.47.0(69991d66135e4a1fc1cf0b1ac4ad25d429866a0d)') == -1)
+                    reject('');
+                  else
+                    resolve('');
+                }
+                else { //custom check (for user specified path)
+                  if (data.indexOf('(AMDLoader || (AMDLoader = {})') == -1 && data.indexOf('//# sourceMappingURL=../../min-maps/vs/loader.js.map') == -1)
+                    reject('');
+                  else
+                    resolve('');
+                }
+          }).catch(error => {
+              reject('');
+          })
+        });
+
+        return promise;
+      }
+
+      const context = AcquireContext.getContext();
+      /*context.pageContext.aadInfo {}
+        .instanceUrl: "https://login.microsoftonline.com"
+        .tenantId: {
+            _guid: 'c5807244-0000-0000-adb9-357387d2a1de'
+          }
+          userId: {
+            _guid: '7de78987-0000-0000-8d17-d19edeab9e41'
+          }
+      */
+      //aadInstanceUrl = 'https://login.microsoftonline.com' / 'https://login.microsoftonline.us' / 'https://login.microsoftonline.microsoft.scloud'
+      //cloudType = 'prod' / 'dod' / 'ag09'
+      //msGraphEndpointUrl = 'https://graph.microsoft.com' / 'https://dod-graph.microsoft.us' / 'https://dod-graph.microsoft.scloud'
+      //webDomain = 'sharepoint.com' / 'sharepoint-mil.us' (even *.dps.mil sites) / 'spo.microsoft.scloud'
+      //substrateEndpointUrl = 'https://substrate.office.com' / 'https://substrate-dod.office365.us' / 'https://substrate.exo.microsoft.scloud'
+      if (context.pageContext.legacyPageContext.aadInstanceUrl && 
+            context.pageContext.legacyPageContext.aadInstanceUrl.endsWith("microsoft.scloud")) {
+        //Override the path
+        CDN_PATH_TO_MONACO_EDITOR = "https://dod365sec.spo.microsoft.scloud/sites/USAF-TipsToolsApps/code/monaco/min/vs";
+        loadMonaco();
+      }
+      else {
+        //Check if monaco is already loaded
+        //@ts-ignore
+        //if (window.monaco)
+        //Would need to store URL value outside/above and then read-in during initalization
+
+        //Since domains can be blocked, check for access first
+        testUrlNetworkAccess(CDN_PATH_TO_MONACO_EDITOR + "/loader.js", true)
+        .then(() => {
+          loadMonaco();
+        })
+        //Error
+        .catch(() => {
+          //Try another one
+          testUrlNetworkAccess("https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/min/vs/loader.js", true)
+          .then(() => {
+            CDN_PATH_TO_MONACO_EDITOR = "https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/min/vs";
+            loadMonaco();
+          })
+          //Error
+          .catch(() => {
+            //Check if query string was found
+            const params = new URLSearchParams(window.location.search);
+            if (params.has("monaco")) {
+              let folderPath = decodeURIComponent(params.get("monaco"));
+              //Removal the ending file part if found
+              folderPath = folderPath.split("/loader.js")[0];
+              //Remove trailing slash if user provided one
+              if (folderPath.lastIndexOf("/") + 1 === folderPath.length)
+                folderPath = folderPath.substring(0, folderPath.length-1);
+
+              //Test to see if this is the expected file
+              testUrlNetworkAccess(folderPath + "/loader.js", false)
+              .then(() => {
+                CDN_PATH_TO_MONACO_EDITOR = folderPath;
+                loadMonaco();
+              })
+              .catch(() => {
+                //Attempt the load anyway so that at least a failure msg is shown if applicable
+                loadMonaco();
+              });
+            }
+          });
+        });
       }
     })().then(() => { /* no-op; */ }).catch(() => { /* no-op; */ });
   }, []);


### PR DESCRIPTION
- Switched CDN loading path for the Monaco (advanced) editor to account for some networks blocking access
- Minor code update to handle existing SPO lists added to the timeline that the current user has no access to
- Fixed bug with the full-width option only works if the section is not collapsible
- Fixed issue with accessing pages over Flow 3/commercial networks causing a page redirect due to "you cannot access from your location" error page
- Fixed bug where setting 0 as either "Days in past…" values would not result in the expected behavior